### PR TITLE
Remove empty title tag from details-JORDANS RETRO.html

### DIFF
--- a/details-JORDANS RETRO.html
+++ b/details-JORDANS RETRO.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" href="shoe-styl.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="style-detail.css">
-  <title></title>
 </head> 
 <body>
   <header class="site-header">


### PR DESCRIPTION
This pull request includes a small change to the `details-JORDANS RETRO.html` file. The change removes an empty `<title>` tag from the HTML document.